### PR TITLE
Fixes schedules not being refreshed after first request error 

### DIFF
--- a/src/controllers/SchedulesController.mjs
+++ b/src/controllers/SchedulesController.mjs
@@ -47,9 +47,17 @@ export class SchedulesController {
     }
     // console.log(`Loading ${pdSchedules}`)
     this.skipLock = true;
-    await this.schedulesService.load(pdSchedules);
+    let result = false;
+    try {
+      await this.schedulesService.load(pdSchedules);
+      // console.log(`Loaded ${pdSchedules}`)
+      result = true;
+    } catch (e) {
+      // Todo: log
+    }
     this.skipLock = false;
-    return true;
+
+    return result;
   }
 
   async index(ctx, format = 'html') {


### PR DESCRIPTION
#### What's this PR do?
- Fixes schedules not being refreshed after first request error by correcting refresh lock mechanism

#### What are the relevant tickets?
Fixes #27 