### PR TITLE
[BUGFIX assets] Fix bundle.css link not using production assets path

### DIFF
--- a/src/views/layout.html.j2
+++ b/src/views/layout.html.j2
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{{title}} | PagerBeauty</title>
-    <link rel="stylesheet" href="/assets/dist/bundle.css">
+    <link rel="stylesheet" href="{{assetsPath}}/bundle.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
#### What's this PR do?
- Fix variable `assetsPath` for bundle.css