### PR TITLE
[CLEANUP misc-release] Improve Semantic Release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -47,7 +47,8 @@ const config = {
     [
       '@semantic-release/git',
       {
-        assets,,
+        assets,
+        // eslint-disable-next-line no-template-curly-in-string
         message: '${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,58 @@
+// Semantic release config object
+const releaseRules = [
+  { breaking: true, release: 'major' },
+  { tag: 'CLEANUP', release: 'patch' },
+  { tag: 'BUGFIX', release: 'patch' },
+  { tag: 'FEATURE', release: 'minor' },
+  { tag: 'SECURITY', release: 'patch' },
+];
+
+const parserOpts = {
+  headerPattern: '\\[(.*) (.*)] ?(.*)',
+  noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+};
+
+const assets = [
+  'CHANGELOG.md',
+  'assets/dist-prod/**/*.{js,css}',
+  'package.json',
+];
+
+const config = {
+  branch: 'production',
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'ember',
+        parserOpts,
+        releaseRules,
+      },
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'ember',
+        parserOpts,
+        releaseRules,
+      },
+    ],
+    [
+      '@semantic-release/changelog',
+      {
+        changelogTitle: '# PagerBeauty Changelog',
+      },
+    ],
+    '@semantic-release/npm',
+    [
+      '@semantic-release/git',
+      {
+        assets,,
+        message: '${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
+    '@semantic-release/github',
+  ],
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -101,47 +101,5 @@
       "@babel/preset-env",
       "@babel/preset-react"
     ]
-  },
-  "release": {
-    "branch": "production",
-    "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "preset": "ember",
-          "parserOpts": {
-            "headerPattern": "\\[(.*) (.*)] ?(.*)"
-          }
-        }
-      ],
-      [
-        "@semantic-release/release-notes-generator",
-        {
-          "preset": "ember",
-          "parserOpts": {
-            "headerPattern": "\\[(.*) (.*)] ?(.*)"
-          }
-        }
-      ],
-      [
-        "@semantic-release/changelog",
-        {
-          "changelogTitle": "# PagerBeauty Changelog"
-        }
-      ],
-      "@semantic-release/npm",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "CHANGELOG.md",
-            "assets/dist-prod/**/*.{js,css}",
-            "package.json"
-          ],
-          "message": "${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ],
-      "@semantic-release/github"
-    ]
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- Move semantic-release config to proper js: `.releaserc.js`
- Setup semantic-release ember preset to support major releases on breaking changes