### PR TITLE
[CLEANUP] Reduce bundle.js size

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "koa-route": "^3.2.0",
     "koa-static": "^5.0.0",
     "koa-views": "^6.1.4",
-    "moment": "^2.22.2",
-    "moment-timezone": "^0.5.23",
     "node-fetch": "^2.2.0",
     "nunjucks": "^3.1.3",
     "url-search-params-polyfill": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "koa-route": "^3.2.0",
     "koa-static": "^5.0.0",
     "koa-views": "^6.1.4",
+    "luxon": "^1.10.0",
     "node-fetch": "^2.2.0",
     "nunjucks": "^3.1.3",
     "url-search-params-polyfill": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "luxon": "^1.10.0",
     "node-fetch": "^2.2.0",
     "nunjucks": "^3.1.3",
-    "url-search-params-polyfill": "^5.0.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,12 @@
   },
   "babel": {
     "presets": [
-      "@babel/preset-env",
+      [
+        "@babel/preset-env",
+        {
+          "useBuiltIns": "usage"
+        }
+      ],
       "@babel/preset-react"
     ]
   }

--- a/src/assets/javascripts/views/OnCallViews.jsx
+++ b/src/assets/javascripts/views/OnCallViews.jsx
@@ -11,11 +11,6 @@ import { Incident } from '../../../models/Incident.mjs';
 import { PagerBeautyFetchNotFoundUiError } from '../ui-errors';
 import { StatusIndicatorView } from './StatusIndicatorView';
 
-
-// ------- Init --------------------------------------------------------------
-
-// const { DateTime } = luxon;
-
 // ------- OnCallView ----------------------------------------------------------
 
 export class OnCallView extends React.Component {

--- a/src/assets/javascripts/views/OnCallViews.jsx
+++ b/src/assets/javascripts/views/OnCallViews.jsx
@@ -1,6 +1,6 @@
 // ------- Imports -------------------------------------------------------------
 
-import moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -10,6 +10,11 @@ import { OnCall } from '../../../models/OnCall.mjs';
 import { Incident } from '../../../models/Incident.mjs';
 import { PagerBeautyFetchNotFoundUiError } from '../ui-errors';
 import { StatusIndicatorView } from './StatusIndicatorView';
+
+
+// ------- Init --------------------------------------------------------------
+
+// const { DateTime } = luxon;
 
 // ------- OnCallView ----------------------------------------------------------
 
@@ -302,7 +307,7 @@ export class OnCallDatesRowView extends React.Component {
 
     // dateEnd is null when there's only one user on schedule.
     let toDate = null;
-    if (onCall.dateEnd.isValid()) {
+    if (onCall.dateEnd.isValid) {
       toDate = (
         <OnCallDateRowView
           className="date_end"
@@ -343,7 +348,7 @@ export class OnCallDateRowView extends React.Component {
 }
 
 OnCallDateRowView.propTypes = {
-  date: PropTypes.instanceOf(moment).isRequired,
+  date: PropTypes.instanceOf(DateTime).isRequired,
   timezone: PropTypes.string,
   className: PropTypes.string,
   label: PropTypes.string,
@@ -389,21 +394,22 @@ OnCallIncidentRowView.defaultProps = {
 export class OnCallDateTimeView extends React.Component {
   render() {
     const { date, timezone } = this.props;
+    let dateInTz = date;
     if (timezone) {
-      date.tz(timezone);
+      dateInTz = date.setZone(timezone);
     }
     return (
       <React.Fragment>
-        <span className="date_weekday">{`${date.format('dddd')}, `}</span>
-        <span className="date_date">{`${date.format('MMM DD')} `}</span>
-        <span className="date_time">{date.format('LT')}</span>
+        <span className="date_weekday">{`${dateInTz.toFormat('EEEE')}, `}</span>
+        <span className="date_date">{`${dateInTz.toFormat('MMM dd')} `}</span>
+        <span className="date_time">{dateInTz.toFormat('t')}</span>
       </React.Fragment>
     );
   }
 }
 
 OnCallDateTimeView.propTypes = {
-  date: PropTypes.instanceOf(moment).isRequired,
+  date: PropTypes.instanceOf(DateTime).isRequired,
   timezone: PropTypes.string,
 };
 

--- a/src/models/OnCall.mjs
+++ b/src/models/OnCall.mjs
@@ -5,12 +5,16 @@
 import 'url';
 
 import 'url-search-params-polyfill';
-import moment from 'moment-timezone';
+import luxon from 'luxon';
 
 // ------- Internal imports ----------------------------------------------------
 
 import { Incident } from './Incident';
 import { Schedule } from './Schedule';
+
+// ------- Init --------------------------------------------------------------
+
+const { DateTime } = luxon;
 
 // ------- OnCall --------------------------------------------------------------
 
@@ -29,8 +33,8 @@ export class OnCall {
     this.userName = userName;
     this.userAvatarURL = userAvatarURL;
     this.userURL = userURL;
-    this.dateStart = moment(dateStart);
-    this.dateEnd = moment(dateEnd);
+    this.dateStart = DateTime.fromISO(dateStart);
+    this.dateEnd = DateTime.fromISO(dateEnd);
     if (schedule instanceof Schedule) {
       this.schedule = schedule;
     } else {
@@ -51,8 +55,8 @@ export class OnCall {
       userName: this.userName,
       userAvatarURL: this.userAvatarURL,
       userURL: this.userURL,
-      dateStart: this.dateStart.utc(),
-      dateEnd: this.dateEnd.utc(),
+      dateStart: this.dateStart.toUTC(),
+      dateEnd: this.dateEnd.toUTC(),
       schedule: this.schedule.serialize(),
       incident: this.incident ? this.incident.serialize() : null,
     };

--- a/src/models/OnCall.mjs
+++ b/src/models/OnCall.mjs
@@ -2,9 +2,6 @@
 
 // This model to be compatible both with backend and frontend.
 
-import 'url';
-
-import 'url-search-params-polyfill';
 import luxon from 'luxon';
 
 // ------- Internal imports ----------------------------------------------------

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,7 +12,7 @@ module.exports = {
       chunkFilename: '[id].css',
     }),
   ],
-  entry: ['babel-polyfill', './src/assets/javascripts/webpack-entry.js'],
+  entry: ['./src/assets/javascripts/webpack-entry.js'],
   output: {
     path: `${__dirname}/assets/dist`,
     // publicPath: '/assets',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,7 +2944,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -4686,7 +4686,7 @@ import-modules@^1.1.0:
   resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-1.1.0.tgz#748db79c5cc42bb9701efab424f894e72600e9dc"
   integrity sha1-dI23nFzEK7lwHvq0JPiU5yYA6dw=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5708,11 +5708,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -5721,32 +5716,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -5842,11 +5815,6 @@ lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -6359,18 +6327,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment-timezone@^0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0", moment@^2.22.2:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
-  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8316,7 +8272,7 @@ readable-stream@~1.1.10, readable-stream@~1.1.11, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,6 +5919,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.10.0.tgz#335b55e2fed50e09f869aee828897a3f67c7044e"
+  integrity sha512-ry3GKh//v3isD6oJN5pFWmdh+3GiScwv9q8VgG6fZ2j1guGOol2vVVdo4GBAWCrcq5RHOqSeipqHBnOu/u024Q==
+
 macos-release@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.0.0.tgz#7dddf4caf79001a851eb4fba7fb6034f251276ab"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9938,11 +9938,6 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-search-params-polyfill@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz#09b98337c89dcf6c6a6a0bfeb096f6ba83b7526b"
-  integrity sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ==
-
 url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"


### PR DESCRIPTION
#### What's this PR do?
1) bundle.js before:
```
1.4M assets/dist-prod/bundle.js
```

2) bundle.js after replacing momentjs with luxon:
```
299K assets/dist-prod/bundle.js
```

3) bundle.js after 2) and setting [`useBuiltIns=usage`](https://babeljs.io/docs/en/babel-preset-env#usebuiltins);
```
244K assets/dist-prod/bundle.js
```

4) bundle js after 3) and removing `url-search-params-polyfill`
```
230K assets/dist-prod/bundle.js
```