### PR TITLE
[CLEANUP docker] Reduce docker image size by cleaning yarn cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR $APP_DIR
 
 # Install
 COPY package.json yarn.lock $APP_DIR/
-RUN yarn install --prod --frozen-lockfile
+RUN yarn install --prod --frozen-lockfile \
+  && yarn cache clean
 
 # Pagerbeauty default port
 EXPOSE 8080

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -17,7 +17,8 @@ WORKDIR $APP_DIR
 
 # Install
 COPY package.json yarn.lock $APP_DIR/
-RUN yarn install --prod --frozen-lockfile
+RUN yarn install --prod --frozen-lockfile \
+  && yarn cache clean
 
 # Pagerbeauty default port
 EXPOSE 8080

--- a/Dockerfile-test-acceptance
+++ b/Dockerfile-test-acceptance
@@ -17,7 +17,8 @@ WORKDIR $APP_DIR
 
 # Install
 COPY package.json yarn.lock $APP_DIR/
-RUN yarn install --prod --frozen-lockfile
+RUN yarn install --prod --frozen-lockfile \
+  && yarn cache clean
 
 # Pagerbeauty default port
 EXPOSE 8080


### PR DESCRIPTION
#### What's this PR do?
- `yarn cache clean` in Docker image after installing production modules

```
92M Mar  9 21:59 pagerbeauty-ci-5eacded7098bbd9cac0f8f3d3c83134276fc15bd.tar.gz
27M Mar  9 23:30 pagerbeauty-ci-a8f7d8fc2c7ae5ee31805466b57b408ef899f1b0.tar.gz
```
