### PR TITLE
[CLEANUP chore-dependencies] Major node upgrade node to the last LTE: 12.14.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     <<: &docker_node
       docker:
-        - image: circleci/node:10.16.0-stretch
+        - image: circleci/node:12.14.1-stretch
     working_directory: ~/repo
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node/
-FROM node:10.16.0-alpine
+FROM node:12.14.1-alpine
 ARG VCS_REF=not_ci
 LABEL org.label-schema.description="PagerDuty on-call dashboard widget" \
       org.label-schema.name="PagerBeauty" \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node/
-FROM node:10.16.0-alpine
+FROM node:12.14.1-alpine
 ARG VCS_REF=not_ci
 LABEL org.label-schema.description="PagerDuty on-call dashboard widget" \
       org.label-schema.name="PagerBeauty" \

--- a/Dockerfile-test-acceptance
+++ b/Dockerfile-test-acceptance
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node/
-FROM node:10.16.0-alpine
+FROM node:12.14.1-alpine
 ARG VCS_REF=not_ci
 LABEL org.label-schema.description="PagerDuty on-call dashboard widget" \
       org.label-schema.name="PagerBeauty" \
@@ -34,9 +34,9 @@ RUN yarn install --frozen-lockfile
 # ---------- Acceptance test image from here
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
 
-# Installs latest Chromium 72.0.3626.121-r0 available in Apline 3.9:
-# Alpine: https://github.com/nodejs/docker-node/blob/170ed2/10/alpine/Dockerfile
-# Chromium: https://pkgs.alpinelinux.org/package/v3.9/community/x86_64/chromium
+# Installs latest Chromium 79.0.3945.88-r0 available in Apline 3.11:
+# Alpine: https://github.com/nodejs/docker-node/blob/8b8ee/12/alpine3.11/Dockerfile
+# Chromium: https://pkgs.alpinelinux.org/package/v3.11/community/x86_64/chromium
 RUN apk update && apk upgrade && \
     apk add --no-cache \
       chromium

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "module": "./src/pagerbeauty",
   "engines": {
     "node": "^12.14.0",
-    "npm": "^6.4.1",
-    "yarn": "^1.12.0"
+    "npm": "^6.13.1",
+    "yarn": "^1.21.1"
   },
   "scripts": {
     "test": "npm run test:unit",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./src/pagerbeauty",
   "module": "./src/pagerbeauty",
   "engines": {
-    "node": "^10.14.0",
+    "node": "^12.14.0",
     "npm": "^6.4.1",
     "yarn": "^1.12.0"
   },


### PR DESCRIPTION
Upgrades:
* `node` from `10.16.0` to `12.14.1`
* `npm` from `6.4.1` to `6.13.1`
* `yarn` from `1.12.0` to `1.21.1`
