### PR TITLE
Open Links To PagerDuty In New Tabs

### DIFF
--- a/src/assets/javascripts/views/OnCallViews.jsx
+++ b/src/assets/javascripts/views/OnCallViews.jsx
@@ -82,7 +82,7 @@ export class OnCallView extends React.Component {
         { /* Schedule name */ }
         {state !== 'not_found' && (
           <OnCallScheduleRowView>
-            <a href={onCall.schedule.url} className="schedule_name">{onCall.schedule.name}</a>
+            <a href={onCall.schedule.url} className="schedule_name" target="_blank" rel="noreferrer">{onCall.schedule.name}</a>
           </OnCallScheduleRowView>
         )}
 
@@ -295,14 +295,14 @@ export class OnCallUserInfoView extends React.Component {
       <>
         <div className="user_avatar">
           {userInfo ? (
-            <a href={userInfo.url}><img src={userInfo.avatar} alt={userInfo.name} /></a>
+            <a href={userInfo.url} target="_blank" rel="noreferrer"><img src={userInfo.avatar} alt={userInfo.name} /></a>
           ) : (
             <img src="https://www.gravatar.com/avatar/0?s=2048&amp;d=mp" alt="Generic avatar" />
           )}
         </div>
         <div className={`user_name ${!userInfo ? 'error' : ''}`}>
           {userInfo ? (
-            <a href={userInfo.url}>{userInfo.name}</a>
+            <a href={userInfo.url} target="_blank" rel="noreferrer">{userInfo.name}</a>
           ) : (
             'No one is on call'
           )}
@@ -401,11 +401,11 @@ export class OnCallIncidentRowView extends React.Component {
       <div className={`incident ${className}`}>
         <div className="incident_summary">
           <span>{`Incident ${incident.status}: `}</span>
-          <a href={incident.url}>{incident.title}</a>
+          <a href={incident.url} target="_blank" rel="noreferrer">{incident.title}</a>
         </div>
         <div className="incident_service">
           <span>Service: </span>
-          <a href={incident.serviceUrl}>{incident.serviceName}</a>
+          <a href={incident.serviceUrl} target="_blank" rel="noreferrer">{incident.serviceName}</a>
         </div>
       </div>
     );


### PR DESCRIPTION
#### What's this PR do?
When embedding a schedule in an iframe, the PagerDuty links are not able
to be opened. This is because PagerDuty sets the 'X-Frame-Options'
header to 'sameorigin', which effectively stops the browser from rending
the page in a iframe.

As such, it's more appropriate to open these links in a new tab.

_Iframe before clicking PagerDuty link:_

![image](https://user-images.githubusercontent.com/6696197/117353449-08c81080-aea8-11eb-82b7-d3d8103c7ce8.png)

_Iframe after clicking PagerDuty link:_

![image](https://user-images.githubusercontent.com/6696197/117353470-0f568800-aea8-11eb-9b13-eda1aae8e4d7.png)

_Console error:_
> Refused to display 'https://apidocs.pagerduty.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.

#### Where should the reviewer start?
N/A

#### How should this be manually tested?
Do the PagerDuty links open in a new tab?

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
N/A
